### PR TITLE
return non-zero in tty mode if err during test

### DIFF
--- a/pkg/cmds/run.go
+++ b/pkg/cmds/run.go
@@ -103,7 +103,7 @@ var runCmd = &cobra.Command{
 				for test, errChan := range channels {
 					err := <-errChan
 					if err != nil {
-						util.Errorf("%s: %s", test, err.Error())
+						util.ErrorFatalf("%s: %s", test, err.Error())
 					}
 				}
 			} else {


### PR DESCRIPTION
i don't see why we'd be getting this error in jenkins though, since that has no-tty and that codepath calls errorfatal

🤔